### PR TITLE
Add web API to expose utils.py functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,57 @@ streamlit run app.py
 3. Get API credentials
 4. Configure environment variables
 
+### Running FastAPI Server
+To run the FastAPI server, use the following command:
+```bash
+uvicorn api:app --reload
+```
+
+### API Endpoints
+The following endpoints are available in the FastAPI server:
+
+- **Token Counting**
+  - **Endpoint**: `/count_tokens/`
+  - **Method**: `POST`
+  - **Request Body**: `{"text": "Your text here"}`
+  - **Response**: `{"token_count": 123}`
+
+- **Text Chunking**
+  - **Endpoint**: `/split_text/`
+  - **Method**: `POST`
+  - **Request Body**: `{"text": "Your text here"}`
+  - **Response**: `{"chunks": ["chunk1", "chunk2"]}`
+
+- **PDF Text Extraction**
+  - **Endpoint**: `/extract_text/`
+  - **Method**: `POST`
+  - **Request Body**: PDF file upload
+  - **Response**: `{"chunks": ["chunk1", "chunk2"], "chunk_tokens": [100, 200]}`
+
+- **Document Summarization**
+  - **Endpoint**: `/summarize/`
+  - **Method**: `POST`
+  - **Request Body**: `{"text": "Your text here"}`
+  - **Response**: `{"summary": "Summary of the text"}`
+
+- **Document Chunk Processing**
+  - **Endpoint**: `/process_chunks/`
+  - **Method**: `POST`
+  - **Request Body**: `{"file_name": "document.pdf", "chunks": ["chunk1", "chunk2"], "chunk_tokens": [100, 200]}`
+  - **Response**: `{"documents": {"doc1": "text1"}, "summaries": {"doc1": "summary1"}, "token_counts": {"doc1": 100}}`
+
+- **Document Relevance Selection**
+  - **Endpoint**: `/select_relevant/`
+  - **Method**: `POST`
+  - **Request Body**: `{"question": "Your question here", "summaries": {"doc1": "summary1"}}`
+  - **Response**: `{"most_relevant": "doc1", "relevance_scores": {"doc1": 90}}`
+
+- **Question Answering**
+  - **Endpoint**: `/get_answer/`
+  - **Method**: `POST`
+  - **Request Body**: `{"question": "Your question here", "document_text": "Relevant document text"}`
+  - **Response**: `{"answer": "Answer to your question"}`
+
 
 ## 💻 Usage
 
@@ -117,6 +168,3 @@ streamlit run app.py
 ### Data Protection
 - No document storage
 - Session-only processing
-
-
-

--- a/README.md
+++ b/README.md
@@ -82,6 +82,42 @@ streamlit run app.py
 3. Get API credentials
 4. Configure environment variables
 
+## 💻 Usage
+
+### Document Upload
+1. Launch the application
+2. Click "Upload Documents"
+3. Select one or more PDF files
+4. Wait for processing completion
+
+### Asking Questions
+1. Type your question in the input field
+2. Click "Submit Question"
+3. View document relevance scores
+4. Read the generated answer
+
+### Understanding Results
+- **Relevance Scores**: Shows how relevant each document is to your question
+- **Token Counts**: Displays processing efficiency metrics
+- **Document Summaries**: Provides quick content overview
+- **System Status**: Shows real-time processing information
+
+## 🛠 Technical Details
+
+### Token Management
+- Maximum tokens per chunk: 120,000
+- Automatic chunking for large documents
+- Token count monitoring
+- Optimization for Azure OpenAI context limits
+
+
+## 🔒 Security
+
+### Data Protection
+- No document storage
+- Session-only processing
+
+
 ### Running FastAPI Server
 To run the FastAPI server, use the following command:
 ```bash
@@ -132,39 +168,3 @@ The following endpoints are available in the FastAPI server:
   - **Method**: `POST`
   - **Request Body**: `{"question": "Your question here", "document_text": "Relevant document text"}`
   - **Response**: `{"answer": "Answer to your question"}`
-
-
-## 💻 Usage
-
-### Document Upload
-1. Launch the application
-2. Click "Upload Documents"
-3. Select one or more PDF files
-4. Wait for processing completion
-
-### Asking Questions
-1. Type your question in the input field
-2. Click "Submit Question"
-3. View document relevance scores
-4. Read the generated answer
-
-### Understanding Results
-- **Relevance Scores**: Shows how relevant each document is to your question
-- **Token Counts**: Displays processing efficiency metrics
-- **Document Summaries**: Provides quick content overview
-- **System Status**: Shows real-time processing information
-
-## 🛠 Technical Details
-
-### Token Management
-- Maximum tokens per chunk: 120,000
-- Automatic chunking for large documents
-- Token count monitoring
-- Optimization for Azure OpenAI context limits
-
-
-## 🔒 Security
-
-### Data Protection
-- No document storage
-- Session-only processing

--- a/api.py
+++ b/api.py
@@ -1,0 +1,57 @@
+from fastapi import FastAPI, UploadFile, File
+from pydantic import BaseModel
+from typing import List, Dict, Tuple
+from utils import count_tokens, split_text_into_chunks, extract_text_from_pdf, get_summary, process_document_chunks, select_relevant_document, get_answer
+
+app = FastAPI()
+
+class TextRequest(BaseModel):
+    text: str
+
+class QuestionRequest(BaseModel):
+    question: str
+    summaries: Dict[str, str]
+
+class DocumentRequest(BaseModel):
+    file_name: str
+    chunks: List[str]
+    chunk_tokens: List[int]
+
+@app.post("/count_tokens/")
+async def count_tokens_endpoint(request: TextRequest):
+    return {"token_count": count_tokens(request.text)}
+
+@app.post("/split_text/")
+async def split_text_endpoint(request: TextRequest):
+    chunks = split_text_into_chunks(request.text)
+    return {"chunks": chunks}
+
+@app.post("/extract_text/")
+async def extract_text_endpoint(file: UploadFile = File(...)):
+    pdf_file = await file.read()
+    chunks, chunk_tokens = extract_text_from_pdf(BytesIO(pdf_file))
+    return {"chunks": chunks, "chunk_tokens": chunk_tokens}
+
+@app.post("/summarize/")
+async def summarize_endpoint(request: TextRequest):
+    summary = get_summary(request.text)
+    return {"summary": summary}
+
+@app.post("/process_chunks/")
+async def process_chunks_endpoint(request: DocumentRequest):
+    documents, summaries, token_counts = process_document_chunks(request.file_name, request.chunks, request.chunk_tokens)
+    return {"documents": documents, "summaries": summaries, "token_counts": token_counts}
+
+@app.post("/select_relevant/")
+async def select_relevant_endpoint(request: QuestionRequest):
+    most_relevant, relevance_scores = select_relevant_document(request.question, request.summaries)
+    return {"most_relevant": most_relevant, "relevance_scores": relevance_scores}
+
+class AnswerRequest(BaseModel):
+    question: str
+    document_text: str
+
+@app.post("/get_answer/")
+async def get_answer_endpoint(request: AnswerRequest):
+    answer = get_answer(request.question, request.document_text)
+    return {"answer": answer}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ PyPDF2>=3.0.0
 openai>=1.2.0
 tiktoken>=0.5.0
 python-dotenv>=1.0.0
+fastapi>=0.70.0
+uvicorn>=0.15.0


### PR DESCRIPTION
Add a FastAPI web API to expose functions from `utils.py`.

* **Add `api.py`**:
  - Import necessary modules including FastAPI, `utils.py`, and Pydantic.
  - Create FastAPI app instance and define API endpoints.
  - Add endpoints for token counting, text chunking, PDF text extraction, document summarization, document chunk processing, document relevance selection, and question answering.

* **Update `requirements.txt`**:
  - Add FastAPI and Uvicorn dependencies.

* **Update `README.md`**:
  - Add instructions to run FastAPI server.
  - Add usage examples for new API endpoints.

---
